### PR TITLE
fix: don't download system2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="garrappachc@gmail.com"
 
 COPY checksum.md5 .
 
+ARG SYSTEM2_FILE_NAME=system2.zip
+
 ARG CONNECTOR_PLUGIN_FILE_NAME=connector.smx
 ARG CONNECTOR_PLUGIN_VERSION=0.6.0
 ARG CONNECTOR_PLUGIN_URL=https://github.com/tf2pickup-org/connector/releases/download/${CONNECTOR_PLUGIN_VERSION}/${CONNECTOR_PLUGIN_FILE_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ LABEL maintainer="garrappachc@gmail.com"
 
 COPY checksum.md5 .
 
-# System2 is dependency of the connector plugin
-ARG SYSTEM2_URL=https://forums.alliedmods.net/attachment.php?attachmentid=188744&d=1618607414
-ARG SYSTEM2_FILE_NAME=system2.zip
-
 ARG CONNECTOR_PLUGIN_FILE_NAME=connector.smx
 ARG CONNECTOR_PLUGIN_VERSION=0.6.0
 ARG CONNECTOR_PLUGIN_URL=https://github.com/tf2pickup-org/connector/releases/download/${CONNECTOR_PLUGIN_VERSION}/${CONNECTOR_PLUGIN_FILE_NAME}
@@ -20,10 +16,11 @@ ARG STAC_PLUGIN_VERSION=v6.0.5
 ARG STAC_PLUGIN_FILE_NAME=stac.zip
 ARG STAC_PLUGIN_URL=https://github.com/sapphonie/StAC-tf2/releases/download/${STAC_PLUGIN_VERSION}/${STAC_PLUGIN_FILE_NAME}
 
+COPY system2.zip .
+
 RUN \
   # download all the plugins
   wget -nv "${CONNECTOR_PLUGIN_URL}" "${TEAMS_PLUGIN_URL}" "${STAC_PLUGIN_URL}" \
-  && wget -nv "${SYSTEM2_URL}" -O "${SYSTEM2_FILE_NAME}" \
   # verify checksums
   && md5sum -c checksum.md5 \
   # install plugins

--- a/checksum.md5
+++ b/checksum.md5
@@ -1,4 +1,3 @@
 4017dfcc0ab75e3194361ed1b6200d87  connector.smx
-ec22c11fdab033ecac5e31af203ba1b7  system2.zip
 de11c6eb3c4a4ea147665e53c211ad08  teams.smx
 7645c11cb05c57960046b1e7a2b2a3b9  stac.zip


### PR DESCRIPTION
As alliedmodders forums disabled downloading of plugins we need to store the system2 plugin in the source tree.